### PR TITLE
Addded 'google-chrome-stable' to list of alternative chrome names

### DIFF
--- a/chromedriver_binary/utils.py
+++ b/chromedriver_binary/utils.py
@@ -98,7 +98,7 @@ def get_chrome_major_version():
     Detects the major version number of the installed chrome/chromium browser.
     :return: The browsers major version number or None
     """
-    browser_executables = ['google-chrome', 'chrome', 'chrome-browser', 'chromium', 'chromium-browser']
+    browser_executables = ['google-chrome', 'chrome', 'chrome-browser', 'google-chrome-stable', 'chromium', 'chromium-browser']
     for browser_executable in browser_executables:
         try:
             version = subprocess.check_output([browser_executable, '--version'])


### PR DESCRIPTION
Addded 'google-chrome-stable' to list of alternative chrome browser names.

This name is used by [official chrome ebuild](https://packages.gentoo.org/packages/www-client/google-chrome) in Gentoo Linux.