### PR TITLE
Add default path to chrome binary on macos

### DIFF
--- a/chromedriver_binary/utils.py
+++ b/chromedriver_binary/utils.py
@@ -99,6 +99,9 @@ def get_chrome_major_version():
     :return: The browsers major version number or None
     """
     browser_executables = ['google-chrome', 'chrome', 'chrome-browser', 'google-chrome-stable', 'chromium', 'chromium-browser']
+    if sys.platform == "darwin":
+        browser_executables.insert(0, "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome")
+
     for browser_executable in browser_executables:
         try:
             version = subprocess.check_output([browser_executable, '--version'])


### PR DESCRIPTION
This is just what the title says 😉 

This adds the default path of the chrome binary to the list of possible browser_executables on macos, if running on macos.