### PR TITLE
Fixes download file name for M1 mac

### DIFF
--- a/chromedriver_binary/utils.py
+++ b/chromedriver_binary/utils.py
@@ -52,7 +52,10 @@ def get_chromedriver_url(version):
         _platform = 'mac'
         architecture = '64'
         if platform.machine() == 'arm64':
-            architecture += '_m1'
+            if version.split('.')[0] < 107:
+                architecture += '_m1'
+            else:
+                architecture = '_arm64'
     elif sys.platform.startswith('win'):
         _platform = 'win'
         architecture = '32'

--- a/chromedriver_binary/utils.py
+++ b/chromedriver_binary/utils.py
@@ -52,7 +52,7 @@ def get_chromedriver_url(version):
         _platform = 'mac'
         architecture = '64'
         if platform.machine() == 'arm64':
-            if version.split('.')[0] < 107:
+            if int(version.split('.')[0]) < 107:
                 architecture += '_m1'
             else:
                 architecture = '_arm64'


### PR DESCRIPTION
Fixed download failures in version later 107 for M1 mac due to Google's change in file name pattern.
Ref: https://chromedriver.storage.googleapis.com/
