### PR TITLE
chore: add encoding= to open() and type hints in setup.py and utils.py

### DIFF
--- a/chromedriver_binary/utils.py
+++ b/chromedriver_binary/utils.py
@@ -20,7 +20,7 @@ except ImportError:
 __author__ = 'Daniel Kaiser <d.kasier@fz-juelich.de>'
 
 
-def get_chromedriver_filename():
+def get_chromedriver_filename() -> str:
     """
     Returns the filename of the binary for the current platform.
     :return: Binary filename
@@ -30,7 +30,7 @@ def get_chromedriver_filename():
     return 'chromedriver'
 
 
-def get_variable_separator():
+def get_variable_separator() -> str:
     """
     Returns the environment variable separator for the current platform.
     :return: Environment variable separator
@@ -40,7 +40,7 @@ def get_variable_separator():
     return ':'
 
 
-def get_legacy_chromedriver_url(version):
+def get_legacy_chromedriver_url(version: int):
     """
     Generates the download URL for legacy releases
     :param version: chromedriver version string
@@ -66,7 +66,7 @@ def get_legacy_chromedriver_url(version):
     return base_url + version + '/chromedriver_' + _platform + architecture + '.zip'
 
 
-def get_chromedriver_url(version):
+def get_chromedriver_url(version: int):
     """
     Generates the download URL for current platform, architecture and the given version.
     Supports Linux, macOS and Windows.
@@ -94,7 +94,7 @@ def get_chromedriver_url(version):
     raise RuntimeError('Could not determine chromedriver download URL for this platform.')
 
 
-def find_binary_in_path(filename):
+def find_binary_in_path(filename: str) -> None:
     """
     Searches for a binary named `filename` in the current PATH. If an executable is found, its absolute path is returned
     else None.
@@ -110,7 +110,7 @@ def find_binary_in_path(filename):
     return None
 
 
-def get_latest_legacy_release_for_version(version):
+def get_latest_legacy_release_for_version(version: int):
     """
     Searches for the latest release (complete version string) for a given major `version` in the legacy storage.
     :param version: Major version number or None
@@ -128,7 +128,7 @@ def get_latest_legacy_release_for_version(version):
         raise RuntimeError('Failed to find release information: {}'.format(release_url))
 
 
-def get_latest_release_for_version(version=None):
+def get_latest_release_for_version(version: int=None):
     """
     Searches for the latest release (complete version string) for a given major `version`. If `version` is None
     the latest Stable release is returned.
@@ -164,7 +164,7 @@ def get_chrome_major_version():
             pass
 
 
-def check_version(binary, required_version):
+def check_version(binary, required_version) -> bool:
     try:
         version = subprocess.check_output([binary, '-v'])
         version = re.match(r'.*?([\d.]+).*?', version.decode('utf-8'))[1]
@@ -182,7 +182,7 @@ def get_chromedriver_path():
     return os.path.abspath(os.path.dirname(__file__))
 
 
-def print_chromedriver_path():
+def print_chromedriver_path() -> None:
     """
     Print the path of the chromedriver binary.
     """

--- a/setup.py
+++ b/setup.py
@@ -18,12 +18,12 @@ except ImportError:
 __author__ = 'Daniel Kaiser <d.kasier@fz-juelich.de>'
 
 
-with open('README.md') as readme_file:
+with open('README.md', encoding="utf-8") as readme_file:
     long_description = readme_file.read()
 
 
 class DownloadChromedriver(build_py):
-    def run(self):
+    def run(self) -> None:
         """
         Downloads, unzips and installs chromedriver.
         If a chromedriver binary is found in PATH it will be copied, otherwise downloaded.


### PR DESCRIPTION
Hello,

I noticed a few areas where the code could be made a bit more robust and readable. This PR focuses on minor housekeeping tasks and does not change any of the existing runtime logic:

### Explicit encoding for file operations
- `setup.py`: added `encoding="utf-8"` to 1 `open()` call(s)

I added explicit encoding here because Python's default behavior depends on the operating system. This change ensures the code handles text consistently whether it is running on Windows, Linux, or macOS, preventing potential UnicodeDecodeErrors.

### Type hint additions
- `setup.py`: added type hints to 1 function(s)
- `utils.py`: added type hints to 9 function(s)

I have added basic type annotations based on variable names and default values. This should make the code easier to work with in modern IDEs without changing any of the actual logic.

### Examples of changes
**Example change in `setup.py`:**
```diff
-with open('README.md') as readme_file:
+with open('README.md', encoding="utf-8") as readme_file:
-    def run(self):
+    def run(self) -> None:
```

**Example change in `utils.py`:**
```diff
-def get_chromedriver_filename():
+def get_chromedriver_filename() -> str:
-def get_variable_separator():
+def get_variable_separator() -> str:
-def get_legacy_chromedriver_url(version):
+def get_legacy_chromedriver_url(version: int):
-def get_chromedriver_url(version):
+def get_chromedriver_url(version: int):
-def find_binary_in_path(filename):
+def find_binary_in_path(filename: str) -> None:
-def get_latest_legacy_release_for_version(version):
+def get_latest_legacy_release_for_version(version: int):
... (truncated for brevity)
```

---

### Safety and verification
- I verified these changes using `ast.parse()` to ensure no syntax errors were introduced.
- Files using dynamic patterns like `eval()` or `globals()` were automatically skipped.
- I did not modify any `__init__.py` files.

Let me know if you would like me to change anything here.